### PR TITLE
trim input value

### DIFF
--- a/src/modules/tasks.js
+++ b/src/modules/tasks.js
@@ -53,7 +53,8 @@ export default class Tasks {
 
   taskExists = (d) => {
     d = d.toLowerCase().trim();
-    const e = this.tasks.filter((t) => t.description.toLowerCase().trim() === d);
+    const e = this.tasks.filter((t) => t.description.toLowerCase().trim()
+      === d);
     return e.length > 0;
   }
 

--- a/src/modules/tasks.js
+++ b/src/modules/tasks.js
@@ -51,7 +51,7 @@ export default class Tasks {
     this.saveTasks();
   }
 
-  taskExists = (d) => {
+  taskExists = (d = '') => {
     d = d.toLowerCase().trim();
     const e = this.tasks.filter((t) => t.description.toLowerCase().trim()
       === d);


### PR DESCRIPTION
This PR changes involve the trimming of `input value` in order to prevent a user from adding an empty task.